### PR TITLE
Day roll over is an hour late, and readystatechange listener runs too early

### DIFF
--- a/src/main/webapp/js/mpData.js
+++ b/src/main/webapp/js/mpData.js
@@ -40,7 +40,7 @@ function updateLibertyUptime() {
     var uptimeReq = new XMLHttpRequest();
 
     uptimeReq.onreadystatechange = function () {
-        if (uptimeReq.status === 200) {
+        if (uptimeReq.readyState == XMLHttpRequest.DONE && uptimeReq.status === 200) {
             var uptime = JSON.parse(uptimeReq.responseText);
             var appTitle = document.getElementById("uptime");
             var newTitle = appTitle.innerText;
@@ -54,7 +54,7 @@ function updateLibertyUptime() {
 
             var days = 0;
 
-            if (hours > 24) {
+            if (hours > 23) {
                 days = Math.floor ( hours / 24 );
                 hours = Math.floor ( hours % 24 );
             }


### PR DESCRIPTION
The current implementation doesn't roll over to days until hour 24 ends rather than begins, so fix that. 

Also the ready state listener triggers when we get the http headers back (i.e. know that we are getting a response), but before we get the response. It then triggers for when we have the response. However this means we get called twice on each uptime call and the first call fails so updated the handler to only trigger when ready state is done.